### PR TITLE
Add preset-driven habit setup with guidance and rewards

### DIFF
--- a/app.css
+++ b/app.css
@@ -31,8 +31,11 @@ h2{font-size:18px;margin:0 0 12px}
   margin-bottom:16px;
 }
 .row{display:flex;gap:8px;align-items:center;margin-bottom:10px}
+.row.column{flex-direction:column;align-items:stretch}
+.row.column label{width:100%;margin-bottom:4px}
+.row.column small{margin-top:4px}
 label{width:120px;color:var(--muted)}
-input[type="text"],input[type="number"]{
+input[type="text"],input[type="number"],select,textarea{
   flex:1;
   padding:10px 12px;
   background:#0b1325;
@@ -41,7 +44,8 @@ input[type="text"],input[type="number"]{
   color:var(--text);
   outline:none;
 }
-input:focus{border-color:var(--accent);box-shadow:0 0 0 4px var(--ring)}
+textarea{min-height:88px;resize:vertical;font-family:inherit}
+input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 4px var(--ring)}
 .btn{
   display:inline-flex;align-items:center;justify-content:center;
   padding:10px 14px;border-radius:12px;border:1px solid #1e293b;
@@ -56,7 +60,9 @@ input:focus{border-color:var(--accent);box-shadow:0 0 0 4px var(--ring)}
   background:var(--card);border:1px solid #162236;border-radius:16px;padding:14px;
   display:flex;flex-direction:column;gap:10px;position:relative;overflow:hidden;
 }
+.habit-header{display:flex;align-items:center;justify-content:space-between;gap:8px}
 .habit h3{margin:0;font-size:16px}
+.habit-description{margin:0;color:var(--muted);font-size:14px}
 .controls{display:flex;align-items:center;gap:8px}
 .count{font-size:28px;font-weight:700;min-width:44px;text-align:center}
 .icon-btn{
@@ -64,15 +70,55 @@ input:focus{border-color:var(--accent);box-shadow:0 0 0 4px var(--ring)}
   width:40px;height:40px;border-radius:12px;border:1px solid #1e293b;
   background:#0b1325;color:var(--text);cursor:pointer;font-size:20px;
 }
-.progress{
+.progress{ 
   height:8px;background:#0b1325;border:1px solid #1e293b;border-radius:999px;overflow:hidden;
 }
 .progress > span{display:block;height:100%;background:linear-gradient(90deg,#22d3ee,#0ea5e9);width:0%}
-.meta{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}
+.meta{display:flex;flex-wrap:wrap;gap:8px;color:var(--muted);font-size:12px}
+.meta span{display:flex;align-items:center;gap:4px}
 .badge{background:#0b1325;border:1px solid #1e293b;border-radius:999px;padding:2px 8px}
+.category-badge{text-transform:uppercase;font-size:10px;letter-spacing:0.08em;font-weight:600}
+.category-build{background:rgba(14,165,233,0.15);border-color:rgba(14,165,233,0.4);color:#38bdf8}
+.category-break{background:rgba(239,68,68,0.18);border-color:rgba(239,68,68,0.4);color:#f87171}
+.category-balance{background:rgba(244,114,182,0.18);border-color:rgba(244,114,182,0.4);color:#f472b6}
+.motivation{
+  margin:0;
+  background:rgba(56,189,248,0.08);
+  border:1px solid rgba(56,189,248,0.2);
+  border-radius:12px;
+  padding:12px;
+  font-style:italic;
+}
+.goals{
+  background:#0b1325;
+  border:1px solid #1e293b;
+  border-radius:12px;
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.goals strong{font-size:13px;letter-spacing:0.04em;text-transform:uppercase;color:var(--muted)}
+.goals ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+.goals li{display:flex;justify-content:space-between;align-items:center;font-size:14px;color:var(--text)}
+.goals li span{color:var(--muted)}
+.guidance{background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:10px 12px}
+.guidance summary{cursor:pointer;font-weight:600;margin-bottom:6px}
+.guidance[open]{padding-bottom:12px}
+.guidance h4{margin:8px 0 4px;font-size:13px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em}
+.guidance ul{margin:0 0 8px 18px;padding:0;color:var(--text);line-height:1.45}
 .actions{display:flex;gap:8px}
 .link{background:none;border:none;color:var(--accent);cursor:pointer;padding:0;font:inherit}
 .link:hover{text-decoration:underline}
+
+.rewards{background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:8px}
+.rewards strong{font-size:13px;letter-spacing:0.04em;text-transform:uppercase;color:var(--muted)}
+.rewards ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column}
+.rewards li{padding:6px 0;display:flex;flex-direction:column;gap:4px}
+.rewards li + li{border-top:1px solid #162236;padding-top:10px;margin-top:4px}
+.rewards li span{font-weight:600;color:var(--text)}
+.rewards li small{color:var(--muted);font-size:12px}
+.rewards .upcoming{color:var(--muted);font-size:12px;margin:0}
 
 #toast{
   position:fixed;left:50%;transform:translateX(-50%);
@@ -82,3 +128,8 @@ input:focus{border-color:var(--accent);box-shadow:0 0 0 4px var(--ring)}
 #toast.show{opacity:1; transform:translate(-50%,-8px)}
 
 .footer{padding:28px 0 40px}
+
+.preset-preview{display:flex;flex-direction:column;gap:6px;margin-bottom:12px;background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:12px}
+.goal-fields{display:flex;flex-direction:column;gap:10px;margin-bottom:10px}
+.goal-fields:empty{margin-bottom:0}
+.hidden{display:none !important}

--- a/app.js
+++ b/app.js
@@ -1,6 +1,363 @@
 /* Tiny offline Habit PWA - localStorage only */
 const STORAGE_KEY = "habitDataV1";
 
+const PRESET_HABITS = [
+  {
+    id: "hydrate-more",
+    name: "Drink more water",
+    category: "Build",
+    defaultTarget: 8,
+    description: "Track each glass so hydration becomes a daily non-negotiable.",
+    motivation: "You’re choosing energy and clarity with every sip—cheers to feeling amazing!",
+    expectedBenefits: [
+      "Steadier energy and improved focus through the afternoon",
+      "Healthier skin and easier recovery after workouts",
+      "Fewer headaches caused by dehydration dips",
+    ],
+    tips: [
+      "Keep a bottle within reach and refill it when you log a glass.",
+      "Front-load the day with water to make hitting your target easier.",
+    ],
+    goalPrompts: [
+      {
+        id: "hydration-goal",
+        label: "Daily water goal (oz)",
+        type: "number",
+        placeholder: "e.g. 80",
+        defaultValue: "80",
+      },
+    ],
+  },
+  {
+    id: "morning-movement",
+    name: "Morning movement",
+    category: "Build",
+    defaultTarget: 1,
+    description: "Carve out time to move your body before the day takes over.",
+    motivation: "Strong mornings build unstoppable momentum for everything else.",
+    expectedBenefits: [
+      "A brighter mood thanks to endorphins first thing",
+      "More consistent progress toward strength or mobility goals",
+    ],
+    tips: [
+      "Lay your gear out the night before so it’s a zero-decision morning.",
+      "Log even short sessions—showing up matters more than perfection.",
+    ],
+    goalPrompts: [
+      {
+        id: "movement-focus",
+        label: "What’s your current focus?",
+        placeholder: "e.g. build core strength",
+      },
+      {
+        id: "movement-duration",
+        label: "Minimum session length",
+        placeholder: "e.g. 20 minutes",
+      },
+    ],
+  },
+  {
+    id: "strength-training",
+    name: "Strength workouts",
+    category: "Build",
+    defaultTarget: 1,
+    description: "Log every strength session so you can celebrate consistency.",
+    motivation: "Every rep is a vote for the stronger version of you—keep stacking wins!",
+    expectedBenefits: [
+      "Noticeable strength gains and body recomposition",
+      "Better posture and fewer nagging aches",
+    ],
+    tips: [
+      "Plan the lifts you’ll tackle before stepping into the gym.",
+      "Track how you feel—progress isn’t only about weight on the bar.",
+    ],
+    goalPrompts: [
+      {
+        id: "target-weight",
+        label: "Target body weight or PR to chase",
+        placeholder: "e.g. 185 lb deadlift",
+      },
+      {
+        id: "weekly-frequency",
+        label: "Sessions you want each week",
+        placeholder: "e.g. 3 strength days",
+      },
+    ],
+  },
+  {
+    id: "mindful-minutes",
+    name: "Mindful minutes",
+    category: "Balance",
+    defaultTarget: 1,
+    description: "Check in with yourself using meditation, breathwork, or quiet time.",
+    motivation: "Grounding yourself for a few minutes keeps the rest of the day calmer.",
+    expectedBenefits: [
+      "Less reactivity when stress shows up",
+      "Better sleep thanks to a softer nervous system",
+    ],
+    tips: [
+      "Pair mindfulness with an existing habit, like morning coffee.",
+      "Try guided sessions if silence feels intimidating at first.",
+    ],
+    goalPrompts: [
+      {
+        id: "mindful-duration",
+        label: "Minutes you’d like to sit",
+        type: "number",
+        placeholder: "e.g. 10",
+        defaultValue: "10",
+      },
+    ],
+  },
+  {
+    id: "sleep-by-11",
+    name: "Sleep before 11",
+    category: "Balance",
+    defaultTarget: 1,
+    description: "Protect your bedtime and unlock steadier mornings.",
+    motivation: "Rest is a superpower—honor it and everything else gets easier.",
+    expectedBenefits: [
+      "Clearer thinking and better mood regulation",
+      "More consistent energy for workouts and hobbies",
+    ],
+    tips: [
+      "Set a wind-down alarm 45 minutes before lights out.",
+      "Keep your bedroom screen-free to cue your brain for rest.",
+    ],
+    goalPrompts: [
+      {
+        id: "bedtime-ritual",
+        label: "Wind-down ritual",
+        placeholder: "e.g. tea + journaling",
+      },
+    ],
+  },
+  {
+    id: "gratitude-notes",
+    name: "Gratitude notes",
+    category: "Build",
+    defaultTarget: 1,
+    description: "Capture one thing you’re grateful for to train your brain on the good.",
+    motivation: "A grateful mind spots possibilities others miss—keep collecting the wins!",
+    expectedBenefits: [
+      "A more optimistic baseline mood",
+      "Stronger relationships as you notice the people who support you",
+    ],
+    tips: [
+      "Pair gratitude journaling with brushing your teeth or bedtime.",
+      "Include gratitude for yourself—celebrate the effort you’re putting in.",
+    ],
+  },
+  {
+    id: "evening-reading",
+    name: "Read before bed",
+    category: "Balance",
+    defaultTarget: 1,
+    description: "Trade a scroll session for a few focused pages at night.",
+    motivation: "Books open new rooms in your mind—this is the doorway.",
+    expectedBenefits: [
+      "Easier time falling asleep without blue light",
+      "Steady progress through your reading list",
+    ],
+    tips: [
+      "Leave your current book on the pillow as a physical cue.",
+      "Set a page or time minimum so “done” feels clear.",
+    ],
+    goalPrompts: [
+      {
+        id: "reading-minutes",
+        label: "Minutes or pages per session",
+        placeholder: "e.g. 15 minutes",
+      },
+    ],
+  },
+  {
+    id: "screen-curfew",
+    name: "Screen-free hour",
+    category: "Balance",
+    defaultTarget: 1,
+    description: "Protect an hour offline to recharge without notifications.",
+    motivation: "Creating intentional quiet time gives your brain the break it craves.",
+    expectedBenefits: [
+      "Deeper focus during work hours",
+      "Better sleep thanks to less late-night stimulation",
+    ],
+    tips: [
+      "Pick a daily slot and schedule something enjoyable in it.",
+      "Charge devices outside the bedroom to remove temptation.",
+    ],
+    goalPrompts: [
+      {
+        id: "curfew-start",
+        label: "When does your screen-free window start?",
+        placeholder: "e.g. 8:30 PM",
+      },
+    ],
+  },
+  {
+    id: "alcohol-free",
+    name: "Alcohol-free days",
+    category: "Break",
+    defaultTarget: 1,
+    description: "Celebrate every day you choose sobriety.",
+    motivation: "Welcome to the rest of your life—each day sober is proof you can rewrite your story.",
+    expectedBenefits: [
+      "Sleep quality rebounds within the first week",
+      "Mood stabilizes and cravings quieten as dopamine resets",
+      "Your body begins repairing liver and immune function",
+    ],
+    tips: [
+      "Plan a replacement ritual for the times you usually drank.",
+      "Reach out to a supporter when a craving hits—connection keeps you grounded.",
+      "Track how your mornings feel as motivation when it’s hard.",
+    ],
+    goalPrompts: [
+      {
+        id: "sober-milestone",
+        label: "Milestone you’re aiming for",
+        placeholder: "e.g. 30 consecutive days",
+      },
+    ],
+  },
+  {
+    id: "smoke-free",
+    name: "Smoke-free streak",
+    category: "Break",
+    defaultTarget: 1,
+    description: "Track every tobacco-free day and watch your streak climb.",
+    motivation: "Your lungs, heart, and future self are cheering for every smoke-free sunrise.",
+    expectedBenefits: [
+      "Breathing becomes easier within a few days",
+      "Sense of taste and smell sharpen after a couple of weeks",
+      "Long-term disease risk drops with every month you stay smoke-free",
+    ],
+    tips: [
+      "Keep quit reasons visible—screenshot them and set as your phone wallpaper.",
+      "Move or breathe deeply when urges peak; cravings usually pass in minutes.",
+    ],
+    goalPrompts: [
+      {
+        id: "quit-support",
+        label: "Support tools you’ll lean on",
+        placeholder: "e.g. nicotine gum, accountability buddy",
+      },
+    ],
+  },
+  {
+    id: "sugar-reset",
+    name: "Sugar reset",
+    category: "Break",
+    defaultTarget: 1,
+    description: "Count the days you choose foods that keep your energy steady.",
+    motivation: "You’re teaching your body to crave what fuels you—every choice counts.",
+    expectedBenefits: [
+      "Smoother energy without the crash",
+      "Clearer skin and improved digestion",
+    ],
+    tips: [
+      "Meal prep snacks that satisfy without added sugar.",
+      "Notice mood changes when you stabilize blood sugar—it’s powerful motivation.",
+    ],
+    goalPrompts: [
+      {
+        id: "sugar-flex",
+        label: "What does success look like?",
+        placeholder: "e.g. dessert only on Saturdays",
+      },
+    ],
+  },
+  {
+    id: "budget-checkin",
+    name: "Budget check-in",
+    category: "Build",
+    defaultTarget: 1,
+    description: "Review spending so money supports the life you’re building.",
+    motivation: "Every check-in is proof you’re steering your finances on purpose.",
+    expectedBenefits: [
+      "Fewer surprise expenses because you catch trends early",
+      "Progress toward savings goals you actually care about",
+    ],
+    tips: [
+      "Pair the check-in with payday or another weekly rhythm.",
+      "Celebrate small wins—transferring even a little to savings counts.",
+    ],
+    goalPrompts: [
+      {
+        id: "savings-goal",
+        label: "Savings or debt goal",
+        placeholder: "e.g. build $1,000 emergency fund",
+      },
+    ],
+  },
+  {
+    id: "creative-time",
+    name: "Creative session",
+    category: "Build",
+    defaultTarget: 1,
+    description: "Protect focused time for art, writing, or music that feeds you.",
+    motivation: "Your creativity needs room to breathe—show up and let it flow.",
+    expectedBenefits: [
+      "A stronger creative identity and body of work",
+      "A healthier outlet for stress and emotions",
+    ],
+    tips: [
+      "Schedule sessions like any other appointment—you’re worth the slot.",
+      "End by jotting what’s next so future-you can start quickly.",
+    ],
+    goalPrompts: [
+      {
+        id: "creative-project",
+        label: "Project you’re nurturing",
+        placeholder: "e.g. finish 3-song EP",
+      },
+      {
+        id: "creative-cadence",
+        label: "Weekly cadence",
+        placeholder: "e.g. 4 sessions a week",
+      },
+    ],
+  },
+];
+
+const REWARD_DEFS = [
+  {
+    id: "first-win",
+    label: "First Win",
+    description: "Logged your first successful day",
+    check: (habit) => daysMeetingTarget(habit) >= 1,
+  },
+  {
+    id: "streak-3",
+    label: "3-Day Streak",
+    description: "Kept your streak alive for three days",
+    check: (habit) => computeStreak(habit) >= 3,
+  },
+  {
+    id: "streak-7",
+    label: "One-Week Streak",
+    description: "Seven days in a row—consistency is building",
+    check: (habit) => computeStreak(habit) >= 7,
+  },
+  {
+    id: "streak-30",
+    label: "30-Day Streak",
+    description: "A full month of keeping promises to yourself",
+    check: (habit) => computeStreak(habit) >= 30,
+  },
+  {
+    id: "progress-50",
+    label: "50 Logs",
+    description: "Logged this habit fifty times",
+    check: (habit) => totalCompletions(habit) >= 50,
+  },
+  {
+    id: "ontrack-25",
+    label: "25 On-Track Days",
+    description: "Hit your daily target on 25 different days",
+    check: (habit) => daysMeetingTarget(habit) >= 25,
+  },
+];
+
 const $ = (sel, el=document) => el.querySelector(sel);
 const $$ = (sel, el=document) => [...el.querySelectorAll(sel)];
 
@@ -42,6 +399,36 @@ function computeStreak(habit, dateISO=todayISO()) {
   return streak;
 }
 
+function totalCompletions(habit) {
+  return Object.values(habit.history || {}).reduce((sum, val) => sum + (val || 0), 0);
+}
+
+function daysMeetingTarget(habit) {
+  const target = habit.target || 1;
+  return Object.values(habit.history || {}).filter(val => (val || 0) >= target).length;
+}
+
+function evaluateRewards(habit) {
+  habit.achievements = habit.achievements || [];
+  const unlockedIds = new Set(habit.achievements.map((a) => a.id));
+  const newlyUnlocked = [];
+
+  REWARD_DEFS.forEach((def) => {
+    if (!unlockedIds.has(def.id) && def.check(habit)) {
+      const reward = {
+        id: def.id,
+        label: def.label,
+        description: def.description,
+        unlockedOn: todayISO(),
+      };
+      habit.achievements.push(reward);
+      newlyUnlocked.push(def.label);
+    }
+  });
+
+  return newlyUnlocked;
+}
+
 function toast(msg) {
   const el = $("#toast");
   el.textContent = msg;
@@ -53,31 +440,59 @@ function render() {
   const state = load();
   const wrap = $("#habits");
   wrap.innerHTML = "";
+
+  let mutated = false;
+  state.habits.forEach((habit) => {
+    const newly = evaluateRewards(habit);
+    if (newly.length) mutated = true;
+  });
+  if (mutated) save(state);
+
   if (!state.habits.length) {
     const empty = document.createElement("div");
     empty.className = "card";
-    empty.innerHTML = "<p>No habits yet. Add your first one above.</p>";
+    empty.innerHTML = "<p>No habits yet. Choose a preset above to get started.</p>";
     wrap.appendChild(empty);
     return;
   }
 
-  state.habits.forEach(h => {
+  state.habits.forEach((h) => {
     const count = getCountFor(h);
     const target = h.target || 1;
-    const progressPct = Math.min(100, Math.round((count / target) * 100));
+    const progressPct = target ? Math.min(100, Math.round((count / target) * 100)) : 0;
 
     const card = document.createElement("article");
     card.className = "habit";
 
+    const header = document.createElement("div");
+    header.className = "habit-header";
+
     const title = document.createElement("h3");
     title.textContent = h.name;
-    card.appendChild(title);
+    header.appendChild(title);
+
+    if (h.category) {
+      const catClass = `category-${h.category.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+      const badge = document.createElement("span");
+      badge.classList.add("category-badge", catClass);
+      badge.textContent = h.category;
+      header.appendChild(badge);
+    }
+
+    card.appendChild(header);
+
+    if (h.description) {
+      const description = document.createElement("p");
+      description.className = "habit-description";
+      description.textContent = h.description;
+      card.appendChild(description);
+    }
 
     const controls = document.createElement("div");
     controls.className = "controls";
     const dec = document.createElement("button");
     dec.className = "icon-btn";
-    dec.setAttribute("aria-label","decrease");
+    dec.setAttribute("aria-label", "decrease");
     dec.textContent = "−";
 
     const countEl = document.createElement("div");
@@ -86,7 +501,7 @@ function render() {
 
     const inc = document.createElement("button");
     inc.className = "icon-btn";
-    inc.setAttribute("aria-label","increase");
+    inc.setAttribute("aria-label", "increase");
     inc.textContent = "+";
 
     controls.append(dec, countEl, inc);
@@ -95,19 +510,131 @@ function render() {
     const prog = document.createElement("div");
     prog.className = "progress";
     const bar = document.createElement("span");
-    bar.style.width = progressPct + "%";
+    bar.style.width = `${progressPct}%`;
     prog.appendChild(bar);
     card.appendChild(prog);
 
     const meta = document.createElement("div");
     meta.className = "meta";
     const targetEl = document.createElement("span");
-    targetEl.innerHTML = `Target <span class="badge">{target}</span>`;
+    targetEl.innerHTML = `Target <span class="badge">${target}</span>`;
     const streak = computeStreak(h);
     const streakEl = document.createElement("span");
-    streakEl.innerHTML = `🔥 <strong>{streak}</strong> day streak`;
+    streakEl.innerHTML = `🔥 <strong>${streak}</strong> day streak`;
     meta.append(targetEl, streakEl);
+    const onTrackDays = daysMeetingTarget(h);
+    if (onTrackDays) {
+      const onTrackEl = document.createElement("span");
+      onTrackEl.innerHTML = `✅ <strong>${onTrackDays}</strong> days on track`;
+      meta.appendChild(onTrackEl);
+    }
     card.appendChild(meta);
+
+    if (h.motivation) {
+      const motivationEl = document.createElement("p");
+      motivationEl.className = "motivation";
+      motivationEl.textContent = h.motivation;
+      card.appendChild(motivationEl);
+    }
+
+    const goalsListData = Array.isArray(h.goals) ? h.goals : [];
+    if (goalsListData.some((goal) => goal && goal.value)) {
+      const goalsBlock = document.createElement("div");
+      goalsBlock.className = "goals";
+      const goalsTitle = document.createElement("strong");
+      goalsTitle.textContent = "Your goals";
+      goalsBlock.appendChild(goalsTitle);
+      const goalsList = document.createElement("ul");
+      goalsListData.forEach((goal) => {
+        if (!goal || !goal.value) return;
+        const item = document.createElement("li");
+        const label = goal.label || "Goal";
+        item.innerHTML = `<span>${label}</span><strong>${goal.value}</strong>`;
+        goalsList.appendChild(item);
+      });
+      if (goalsList.childElementCount) goalsBlock.appendChild(goalsList);
+      card.appendChild(goalsBlock);
+    }
+
+    const expected = Array.isArray(h.expectedBenefits)
+      ? h.expectedBenefits
+      : h.expectedBenefits
+      ? [h.expectedBenefits]
+      : [];
+    const tips = Array.isArray(h.tips) ? h.tips : h.tips ? [h.tips] : [];
+
+    if (expected.length || tips.length) {
+      const details = document.createElement("details");
+      details.className = "guidance";
+      const summary = document.createElement("summary");
+      summary.textContent = "What to expect & tips";
+      details.appendChild(summary);
+
+      if (expected.length) {
+        const expectTitle = document.createElement("h4");
+        expectTitle.textContent = "What to expect";
+        details.appendChild(expectTitle);
+        const expectList = document.createElement("ul");
+        expected.forEach((benefit) => {
+          const item = document.createElement("li");
+          item.textContent = benefit;
+          expectList.appendChild(item);
+        });
+        details.appendChild(expectList);
+      }
+
+      if (tips.length) {
+        const tipsTitle = document.createElement("h4");
+        tipsTitle.textContent = "Tips to stay on track";
+        details.appendChild(tipsTitle);
+        const tipsList = document.createElement("ul");
+        tips.forEach((tip) => {
+          const item = document.createElement("li");
+          item.textContent = tip;
+          tipsList.appendChild(item);
+        });
+        details.appendChild(tipsList);
+      }
+
+      card.appendChild(details);
+    }
+
+    const achievements = (h.achievements || []).slice().sort((a, b) => {
+      if (!a.unlockedOn) return 1;
+      if (!b.unlockedOn) return -1;
+      return a.unlockedOn < b.unlockedOn ? 1 : -1;
+    });
+    const rewardBlock = document.createElement("div");
+    rewardBlock.className = "rewards";
+    const rewardTitle = document.createElement("strong");
+    rewardTitle.textContent = "Rewards";
+    rewardBlock.appendChild(rewardTitle);
+
+    if (achievements.length) {
+      const list = document.createElement("ul");
+      achievements.forEach((ach) => {
+        const item = document.createElement("li");
+        const date = ach.unlockedOn ? ` · ${ach.unlockedOn}` : "";
+        item.innerHTML = `<span>${ach.label}</span><small>${ach.description}${date}</small>`;
+        list.appendChild(item);
+      });
+      rewardBlock.appendChild(list);
+    } else {
+      const emptyReward = document.createElement("p");
+      emptyReward.className = "muted";
+      emptyReward.textContent = "Keep logging to unlock your first reward.";
+      rewardBlock.appendChild(emptyReward);
+    }
+
+    const achievedIds = new Set(achievements.map((a) => a.id));
+    const nextReward = REWARD_DEFS.find((def) => !achievedIds.has(def.id));
+    if (nextReward) {
+      const next = document.createElement("p");
+      next.className = "upcoming";
+      next.textContent = `Next: ${nextReward.label} — ${nextReward.description}`;
+      rewardBlock.appendChild(next);
+    }
+    card.appendChild(rewardBlock);
 
     const actions = document.createElement("div");
     actions.className = "actions";
@@ -123,18 +650,22 @@ function render() {
 
     inc.addEventListener("click", () => {
       const s = load();
-      const hh = s.habits.find(x => x.id === h.id);
+      const hh = s.habits.find((x) => x.id === h.id);
       const c = getCountFor(hh) + 1;
       setCountFor(hh, c);
+      const newRewards = evaluateRewards(hh);
       save(s);
-      // hit target celebration
-      if (c === target) toast(`Nice! You hit your “${hh.name}” target 🎉`);
+      const messages = [];
+      const targetVal = hh.target || 1;
+      if (c === targetVal) messages.push(`Nice! You hit your “${hh.name}” target 🎉`);
+      if (newRewards.length) messages.push(`Unlocked: ${newRewards.join(", ")}`);
+      if (messages.length) toast(messages.join(" • "));
       render();
     });
 
     dec.addEventListener("click", () => {
       const s = load();
-      const hh = s.habits.find(x => x.id === h.id);
+      const hh = s.habits.find((x) => x.id === h.id);
       const c = Math.max(0, getCountFor(hh) - 1);
       setCountFor(hh, c);
       save(s);
@@ -143,7 +674,7 @@ function render() {
 
     reset.addEventListener("click", () => {
       const s = load();
-      const hh = s.habits.find(x => x.id === h.id);
+      const hh = s.habits.find((x) => x.id === h.id);
       setCountFor(hh, 0);
       save(s);
       render();
@@ -151,7 +682,7 @@ function render() {
 
     del.addEventListener("click", () => {
       const s = load();
-      s.habits = s.habits.filter(x => x.id !== h.id);
+      s.habits = s.habits.filter((x) => x.id !== h.id);
       save(s);
       render();
     });
@@ -160,44 +691,238 @@ function render() {
   });
 }
 
-$("#add-form").addEventListener("submit", (e) => {
-  e.preventDefault();
-  const name = $("#name").value.trim();
-  const target = Math.max(1, parseInt($("#target").value,10) || 1);
-  if (!name) return;
+function splitLines(value="") {
+  return value
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
 
-  const state = load();
-  state.habits.push({
+function createHabitFromPreset(preset) {
+  if (!preset) return null;
+  const habit = {
     id: uid(),
-    name,
-    target,
+    name: preset.name,
+    target: preset.defaultTarget || 1,
     createdAt: new Date().toISOString(),
     history: {},
-  });
-  save(state);
+    presetId: preset.id,
+    category: preset.category,
+    description: preset.description,
+    motivation: preset.motivation || "",
+    expectedBenefits: (preset.expectedBenefits || []).slice(),
+    tips: (preset.tips || []).slice(),
+    goals: (preset.goalPrompts || [])
+      .map((prompt) => ({
+        id: prompt.id,
+        label: prompt.label,
+        value: prompt.defaultValue || "",
+      }))
+      .filter((goal) => goal.value),
+    achievements: [],
+  };
+  return habit;
+}
 
-  $("#name").value = "";
-  $("#target").value = "1";
-  render();
-});
+const addForm = $("#add-form");
+const presetSelect = $("#preset");
+const nameInput = $("#name");
+const targetInput = $("#target");
+const motivationInput = $("#motivation");
+const expectedInput = $("#expected");
+const tipsInput = $("#tips");
+const goalFields = $("#goal-fields");
+const presetPreview = $("#preset-preview");
+const presetCategory = $("#preset-category");
+const presetDescription = $("#preset-description");
+
+function renderGoalInputs(preset) {
+  if (!goalFields) return;
+  goalFields.innerHTML = "";
+  if (!preset || !Array.isArray(preset.goalPrompts) || !preset.goalPrompts.length) return;
+
+  preset.goalPrompts.forEach((prompt) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "row column goal-field";
+    const id = `goal-${prompt.id}`;
+
+    const label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.textContent = prompt.label || "Goal";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.className = "goal-input";
+    input.type = prompt.type || "text";
+    input.placeholder = prompt.placeholder || "";
+    input.value = prompt.defaultValue || "";
+    input.dataset.goalId = prompt.id || id;
+    input.dataset.goalLabel = prompt.label || "Goal";
+
+    wrapper.append(label, input);
+
+    if (prompt.helper) {
+      const hint = document.createElement("small");
+      hint.className = "muted";
+      hint.textContent = prompt.helper;
+      wrapper.appendChild(hint);
+    }
+
+    goalFields.appendChild(wrapper);
+  });
+}
+
+function updatePresetPreview(preset) {
+  if (!presetPreview) return;
+  if (!preset) {
+    presetPreview.classList.add("hidden");
+    if (presetCategory) presetCategory.textContent = "";
+    if (presetDescription) presetDescription.textContent = "";
+    if (presetCategory) presetCategory.className = "badge category-badge";
+    return;
+  }
+
+  const catClass = `category-${preset.category.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+  presetPreview.classList.remove("hidden");
+  if (presetCategory) {
+    presetCategory.className = `badge category-badge ${catClass}`;
+    presetCategory.textContent = preset.category;
+  }
+  if (presetDescription) {
+    presetDescription.textContent = preset.description || "";
+  }
+}
+
+function applyPresetToForm(preset) {
+  if (preset) {
+    if (nameInput) nameInput.value = preset.name;
+    if (targetInput) targetInput.value = String(preset.defaultTarget || 1);
+    if (motivationInput) motivationInput.value = preset.motivation || "";
+    if (expectedInput) expectedInput.value = (preset.expectedBenefits || []).join("\n");
+    if (tipsInput) tipsInput.value = (preset.tips || []).join("\n");
+  } else {
+    if (nameInput) nameInput.value = "";
+    if (targetInput) targetInput.value = "1";
+    if (motivationInput) motivationInput.value = "";
+    if (expectedInput) expectedInput.value = "";
+    if (tipsInput) tipsInput.value = "";
+  }
+  renderGoalInputs(preset || null);
+  updatePresetPreview(preset || null);
+}
+
+function populatePresetOptions() {
+  if (!presetSelect) return;
+  presetSelect.innerHTML = "";
+  const customOption = document.createElement("option");
+  customOption.value = "";
+  customOption.textContent = "Custom habit";
+  presetSelect.appendChild(customOption);
+
+  const categoryLabels = {
+    Build: "Build new routines",
+    Break: "Break old habits",
+    Balance: "Balance & recovery",
+  };
+
+  const categories = [];
+  PRESET_HABITS.forEach((preset) => {
+    if (!categories.includes(preset.category)) categories.push(preset.category);
+  });
+
+  categories.forEach((category) => {
+    const group = document.createElement("optgroup");
+    group.label = categoryLabels[category] || category;
+    PRESET_HABITS.filter((p) => p.category === category).forEach((preset) => {
+      const option = document.createElement("option");
+      option.value = preset.id;
+      option.textContent = preset.name;
+      group.appendChild(option);
+    });
+    presetSelect.appendChild(group);
+  });
+}
+
+function handlePresetChange() {
+  if (!presetSelect) return;
+  const selectedId = presetSelect.value;
+  const preset = PRESET_HABITS.find((p) => p.id === selectedId) || null;
+  applyPresetToForm(preset);
+}
+
+if (presetSelect) {
+  populatePresetOptions();
+  handlePresetChange();
+  presetSelect.addEventListener("change", handlePresetChange);
+}
+
+if (addForm) {
+  addForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const name = nameInput ? nameInput.value.trim() : "";
+    const target = Math.max(1, parseInt(targetInput?.value || "1", 10) || 1);
+    if (!name) return;
+
+    const preset = presetSelect ? PRESET_HABITS.find((p) => p.id === presetSelect.value) : null;
+    const motivation = motivationInput ? motivationInput.value.trim() : "";
+    const expectedBenefits = expectedInput ? splitLines(expectedInput.value) : [];
+    const tips = tipsInput ? splitLines(tipsInput.value) : [];
+    const goals = goalFields
+      ? $$(".goal-input", goalFields)
+          .map((input) => {
+            const value = input.value.trim();
+            if (!value) return null;
+            return {
+              id: input.dataset.goalId || uid(),
+              label: input.dataset.goalLabel || "Goal",
+              value,
+            };
+          })
+          .filter(Boolean)
+      : [];
+
+    const habit = {
+      id: uid(),
+      name,
+      target,
+      createdAt: new Date().toISOString(),
+      history: {},
+      motivation,
+      expectedBenefits,
+      tips,
+      goals,
+      achievements: [],
+    };
+
+    if (preset) {
+      habit.presetId = preset.id;
+      habit.category = preset.category;
+      habit.description = preset.description;
+      if (!habit.expectedBenefits.length && preset.expectedBenefits) habit.expectedBenefits = [...preset.expectedBenefits];
+      if (!habit.tips.length && preset.tips) habit.tips = [...preset.tips];
+      if (!habit.motivation && preset.motivation) habit.motivation = preset.motivation;
+    }
+
+    const state = load();
+    state.habits.push(habit);
+    save(state);
+
+    addForm.reset();
+    if (presetSelect) presetSelect.value = "";
+    applyPresetToForm(null);
+    render();
+  });
+}
 
 // seed with example if first launch
 (function init(){
   const state = load();
   if (!state.habits.length) {
-    state.habits.push({
-      id: uid(),
-      name: "Drink water",
-      target: 8,
-      createdAt: new Date().toISOString(),
-      history: {"2025-09-17": 0},
-    });
-    state.habits.push({
-      id: uid(),
-      name: "Walk",
-      target: 1,
-      createdAt: new Date().toISOString(),
-      history: {"2025-09-17": 0},
+    const starterIds = ["hydrate-more", "alcohol-free"];
+    starterIds.forEach((id) => {
+      const preset = PRESET_HABITS.find((p) => p.id === id);
+      const habit = createHabitFromPreset(preset);
+      if (habit) state.habits.push(habit);
     });
     save(state);
   }

--- a/index.html
+++ b/index.html
@@ -21,8 +21,18 @@
 
     <main class="container">
       <section class="card">
-        <h2>Add a habit</h2>
+        <h2>Plan your habit</h2>
         <form id="add-form" autocomplete="off">
+          <div class="row">
+            <label for="preset">Starter ideas</label>
+            <select id="preset" name="preset">
+              <option value="">Custom habit</option>
+            </select>
+          </div>
+          <div id="preset-preview" class="preset-preview hidden">
+            <span id="preset-category" class="badge category-badge"></span>
+            <p id="preset-description" class="muted"></p>
+          </div>
           <div class="row">
             <label for="name">Name</label>
             <input id="name" name="name" type="text" placeholder="Drink water" required />
@@ -31,7 +41,21 @@
             <label for="target">Daily target</label>
             <input id="target" name="target" type="number" min="1" value="1" required />
           </div>
-          <button type="submit" class="btn">Add</button>
+          <div id="goal-fields" class="goal-fields"></div>
+          <div class="row column">
+            <label for="motivation">Motivation</label>
+            <textarea id="motivation" name="motivation" placeholder="Write a short pep talk you'll see on the habit card"></textarea>
+            <small class="muted">This message appears on your habit card.</small>
+          </div>
+          <div class="row column">
+            <label for="expected">What to expect</label>
+            <textarea id="expected" name="expected" placeholder="List the benefits you’re working toward. One per line."></textarea>
+          </div>
+          <div class="row column">
+            <label for="tips">Tips to stay on track</label>
+            <textarea id="tips" name="tips" placeholder="Add practical reminders. One per line."></textarea>
+          </div>
+          <button type="submit" class="btn">Start tracking</button>
         </form>
       </section>
 


### PR DESCRIPTION
## Summary
- add a curated preset catalog with categories, motivation copy, benefits, and goal prompts
- redesign the habit creation form to pick presets and tailor goals, expectations, and tips
- surface motivation, guidance, and persistent achievement rewards on each habit card

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9a0d02188333b98cd07bb970db6e