### PR TITLE
Add habit start scheduling and reminders

### DIFF
--- a/app.css
+++ b/app.css
@@ -35,7 +35,7 @@ h2{font-size:18px;margin:0 0 12px}
 .row.column label{width:100%;margin-bottom:4px}
 .row.column small{margin-top:4px}
 label{width:120px;color:var(--muted)}
-input[type="text"],input[type="number"],select,textarea{
+input[type="text"],input[type="number"],input[type="date"],input[type="time"],select,textarea{
   flex:1;
   padding:10px 12px;
   background:#0b1325;
@@ -46,6 +46,8 @@ input[type="text"],input[type="number"],select,textarea{
 }
 textarea{min-height:88px;resize:vertical;font-family:inherit}
 input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 4px var(--ring)}
+.dual-inputs{display:flex;gap:8px;width:100%}
+.dual-inputs input{flex:1}
 .btn{
   display:inline-flex;align-items:center;justify-content:center;
   padding:10px 14px;border-radius:12px;border:1px solid #1e293b;
@@ -64,13 +66,15 @@ input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 
 .habit h3{margin:0;font-size:16px}
 .habit-description{margin:0;color:var(--muted);font-size:14px}
 .controls{display:flex;align-items:center;gap:8px}
+.controls.disabled{opacity:0.5}
 .count{font-size:28px;font-weight:700;min-width:44px;text-align:center}
 .icon-btn{
   display:inline-flex;align-items:center;justify-content:center;
   width:40px;height:40px;border-radius:12px;border:1px solid #1e293b;
   background:#0b1325;color:var(--text);cursor:pointer;font-size:20px;
 }
-.progress{ 
+.icon-btn:disabled{cursor:not-allowed;opacity:0.4}
+.progress{
   height:8px;background:#0b1325;border:1px solid #1e293b;border-radius:999px;overflow:hidden;
 }
 .progress > span{display:block;height:100%;background:linear-gradient(90deg,#22d3ee,#0ea5e9);width:0%}
@@ -110,6 +114,8 @@ input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 
 .actions{display:flex;gap:8px}
 .link{background:none;border:none;color:var(--accent);cursor:pointer;padding:0;font:inherit}
 .link:hover{text-decoration:underline}
+.link:disabled{color:var(--muted);cursor:not-allowed;text-decoration:none;opacity:0.6}
+.link:disabled:hover{text-decoration:none}
 
 .rewards{background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:8px}
 .rewards strong{font-size:13px;letter-spacing:0.04em;text-transform:uppercase;color:var(--muted)}
@@ -119,6 +125,16 @@ input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 
 .rewards li span{font-weight:600;color:var(--text)}
 .rewards li small{color:var(--muted);font-size:12px}
 .rewards .upcoming{color:var(--muted);font-size:12px;margin:0}
+
+.start-countdown{
+  margin:0;
+  background:rgba(148,163,184,0.12);
+  border:1px solid rgba(148,163,184,0.2);
+  border-radius:12px;
+  padding:10px 12px;
+  color:var(--muted);
+  font-size:14px;
+}
 
 #toast{
   position:fixed;left:50%;transform:translateX(-50%);

--- a/index.html
+++ b/index.html
@@ -41,6 +41,14 @@
             <label for="target">Daily target</label>
             <input id="target" name="target" type="number" min="1" value="1" required />
           </div>
+          <div class="row column">
+            <label for="start-date">Start day &amp; reminder</label>
+            <div class="dual-inputs">
+              <input id="start-date" name="startDate" type="date" />
+              <input id="reminder-time" name="reminderTime" type="time" />
+            </div>
+            <small class="muted">Choose when you want to begin and an optional daily reminder time.</small>
+          </div>
           <div id="goal-fields" class="goal-fields"></div>
           <div class="row column">
             <label for="motivation">Motivation</label>


### PR DESCRIPTION
## Summary
- add start date and reminder inputs to the habit planner form
- persist start and reminder metadata, update streak/count helpers, and surface countdown UI before a habit begins
- queue daily reminders via localStorage/service worker and keep existing habits aligned with their creation date

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc6d3cc4a883338609a1ced04985f5