### PR TITLE
Add scheduling timeline and calendar export

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 A tiny, offline-first habit counter with streaks. Works on your phone and can be installed like an app.
 
-## What it does (v1)
+## What it does
 - Add habits with a daily target (e.g., 8 glasses of water).
-- Tap + / − to track your count for **today**.
+- Choose a cadence (every day, specific weekdays, or a one-time event) and see it laid out on each habit’s timeline.
+- Tap + / − to track your count for **today** and keep the timeline in sync.
+- Missed scheduled days trigger an optional notification prompt (✅/❌) if you’ve allowed notifications.
+- Export the cadence as an `.ics` calendar file so you can subscribe in your calendar app.
 - Shows a 🔥 day streak when you meet the target across consecutive days.
 - Fully offline (data stored locally on your device via localStorage).
 - Installable PWA (Add to Home Screen).
@@ -28,6 +31,12 @@ A tiny, offline-first habit counter with streaks. Works on your phone and can be
 ## Customize
 - Edit `index.html` labels and colors in `app.css`.
 - In `app.js`, adjust the simple data model or add features like weekly targets or reminders.
+
+## Timeline & prompts
+- Each habit now renders a mini calendar that highlights completed, pending (today), upcoming and missed check-ins.
+- Missed days within the last week will ping the service worker, which raises a “Did you complete…?” notification. Tapping ✅ logs the day at your target; ❌ dismisses the prompt for that day.
+- “Add to calendar” downloads an `.ics` file with your habit cadence (daily RRULE, weekly BYDAY, or one-off). Subscribe to stay synced across devices.
+- One-off events disappear from the timeline once their day passes—log them or mark them from the notification to keep your history tidy.
 
 ## Roadmap ideas (optional)
 - Cloud sync (Supabase or Firebase auth + database).

--- a/app.css
+++ b/app.css
@@ -107,7 +107,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 
 .guidance[open]{padding-bottom:12px}
 .guidance h4{margin:8px 0 4px;font-size:13px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em}
 .guidance ul{margin:0 0 8px 18px;padding:0;color:var(--text);line-height:1.45}
-.actions{display:flex;gap:8px}
+.actions{display:flex;gap:8px;flex-wrap:wrap}
 .link{background:none;border:none;color:var(--accent);cursor:pointer;padding:0;font:inherit}
 .link:hover{text-decoration:underline}
 
@@ -132,4 +132,31 @@ input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 
 .preset-preview{display:flex;flex-direction:column;gap:6px;margin-bottom:12px;background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:12px}
 .goal-fields{display:flex;flex-direction:column;gap:10px;margin-bottom:10px}
 .goal-fields:empty{margin-bottom:0}
+.field-label{color:var(--muted);font-size:12px;letter-spacing:0.06em;text-transform:uppercase;font-weight:600}
+.weekday-picker{display:flex;flex-wrap:wrap;gap:6px}
+.weekday-toggle{display:inline-flex;position:relative;cursor:pointer;font-size:13px}
+.weekday-toggle input{position:absolute;opacity:0;pointer-events:none}
+.weekday-toggle span{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border:1px solid #1e293b;border-radius:999px;background:#0b1325;color:var(--muted);transition:all .2s}
+.weekday-toggle span::before{content:"";width:14px;height:14px;border:1px solid #1e293b;border-radius:4px;background:#0b1325;transition:all .2s}
+.weekday-toggle input:checked + span{color:var(--text);border-color:var(--accent);box-shadow:0 0 0 2px rgba(14,165,233,0.25);background:rgba(14,165,233,0.12)}
+.weekday-toggle input:checked + span::before{background:var(--accent);border-color:var(--accent);box-shadow:0 0 0 2px rgba(14,165,233,0.25)}
+.schedule-note{font-size:13px;margin:8px 0 0}
+.schedule-block{background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:10px}
+.schedule-block strong{font-size:13px;letter-spacing:0.05em;text-transform:uppercase;color:var(--muted)}
+.schedule-description{color:var(--muted);font-size:12px}
+.timeline{list-style:none;margin:0;padding:0;display:flex;gap:8px;overflow-x:auto}
+.timeline-item{min-width:72px;background:#0b1325;border:1px solid #1e293b;border-radius:12px;padding:8px 10px;display:flex;flex-direction:column;gap:4px;align-items:flex-start;font-size:12px}
+.timeline-item strong{font-size:14px;color:var(--text)}
+.timeline-day{color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:0.06em;font-size:11px}
+.timeline-status{font-size:11px;text-transform:uppercase;letter-spacing:0.06em}
+.timeline-item.complete{border-color:rgba(34,197,94,0.6);background:rgba(34,197,94,0.12)}
+.timeline-item.complete .timeline-status{color:var(--success)}
+.timeline-item.missed{border-color:rgba(239,68,68,0.5);background:rgba(239,68,68,0.1)}
+.timeline-item.missed .timeline-status{color:var(--danger)}
+.timeline-item.pending{border-color:rgba(250,204,21,0.5);background:rgba(250,204,21,0.12)}
+.timeline-item.pending .timeline-status{color:#facc15}
+.timeline-item.upcoming{opacity:0.8}
+.timeline-item.today strong{color:var(--accent)}
+.timeline-item.today .timeline-status{color:var(--accent)}
+.timeline-empty{color:var(--muted);font-size:12px;margin:0}
 .hidden{display:none !important}

--- a/index.html
+++ b/index.html
@@ -41,12 +41,42 @@
             <label for="target">Daily target</label>
             <input id="target" name="target" type="number" min="1" value="1" required />
           </div>
+          <div class="row">
+            <label for="start-date">Start date</label>
+            <input id="start-date" name="start-date" type="date" required />
+          </div>
+          <div class="row">
+            <label for="schedule-frequency">Schedule</label>
+            <select id="schedule-frequency" name="schedule-frequency">
+              <option value="daily">Every day</option>
+              <option value="weekly">Specific weekdays</option>
+              <option value="once">One-time check-in</option>
+            </select>
+          </div>
+          <div id="weekly-picker" class="row column hidden">
+            <span class="field-label">Weekdays</span>
+            <div class="weekday-picker" role="group" aria-label="Choose weekdays for this habit">
+              <label class="weekday-toggle"><input type="checkbox" value="MO" /><span>Mon</span></label>
+              <label class="weekday-toggle"><input type="checkbox" value="TU" /><span>Tue</span></label>
+              <label class="weekday-toggle"><input type="checkbox" value="WE" /><span>Wed</span></label>
+              <label class="weekday-toggle"><input type="checkbox" value="TH" /><span>Thu</span></label>
+              <label class="weekday-toggle"><input type="checkbox" value="FR" /><span>Fri</span></label>
+              <label class="weekday-toggle"><input type="checkbox" value="SA" /><span>Sat</span></label>
+              <label class="weekday-toggle"><input type="checkbox" value="SU" /><span>Sun</span></label>
+            </div>
+            <small class="muted">Pick the days you want to see on your timeline.</small>
+          </div>
+          <div id="event-date-row" class="row hidden">
+            <label for="event-date">Event date</label>
+            <input id="event-date" name="event-date" type="date" />
+          </div>
           <div id="goal-fields" class="goal-fields"></div>
           <div class="row column">
             <label for="motivation">Motivation</label>
             <textarea id="motivation" name="motivation" placeholder="Write a short pep talk you'll see on the habit card"></textarea>
             <small class="muted">This message appears on your habit card.</small>
           </div>
+          <p class="muted schedule-note">You'll get a mini calendar for each habit. If a scheduled check-in passes without a log, we'll nudge you (if notifications are allowed) and you can add the cadence to your calendar app.</p>
           <div class="row column">
             <label for="expected">What to expect</label>
             <textarea id="expected" name="expected" placeholder="List the benefits you’re working toward. One per line."></textarea>

--- a/service-worker.js
+++ b/service-worker.js
@@ -39,7 +39,71 @@ self.addEventListener("fetch", (e) => {
       }
       return fresh;
     } catch (err) {
-      return cached || new Response("Offline", {{ status: 200, headers: {{ "Content-Type": "text/plain" }} }});
+      return cached || new Response("Offline", { status: 200, headers: { "Content-Type": "text/plain" } });
     }
   })());
+});
+
+function formatNotificationDate(iso) {
+  if (!iso) return "today";
+  try {
+    const date = new Date(`${iso}T00:00:00`);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    }
+  } catch (err) {
+    // ignore
+  }
+  return iso;
+}
+
+self.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type !== "habit-missed") return;
+  if (!data.habitId || !data.name || !data.date) return;
+  const title = `Did you complete ${data.name}?`;
+  const body = `Your ${formatNotificationDate(data.date)} check-in is still open.`;
+  const options = {
+    body,
+    tag: `${data.habitId}-${data.date}`,
+    data: { habitId: data.habitId, date: data.date },
+    actions: [
+      { action: "habit-complete", title: "✅ Yes" },
+      { action: "habit-skip", title: "❌ Not today" },
+    ],
+    requireInteraction: false,
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  const { notification, action } = event;
+  const data = notification.data || {};
+  notification.close();
+
+  const handleClick = async () => {
+    const clientList = await clients.matchAll({ type: "window", includeUncontrolled: true });
+    if (action === "habit-complete" || action === "habit-skip") {
+      const responseAction = action === "habit-complete" ? "complete" : "skip";
+      clientList.forEach((client) => {
+        client.postMessage({
+          type: "habit-response",
+          habitId: data.habitId,
+          date: data.date,
+          action: responseAction,
+        });
+      });
+      if (!clientList.length) {
+        await clients.openWindow("./");
+      }
+    } else {
+      if (clientList.length) {
+        clientList[0].focus();
+      } else {
+        await clients.openWindow("./");
+      }
+    }
+  };
+
+  event.waitUntil(handleClick());
 });


### PR DESCRIPTION
## Summary
- capture scheduling metadata for each habit and normalize it for existing data
- render a timeline calendar, trigger missed-day notifications, and handle service-worker actions
- add calendar export support, update styles, and document the new cadence workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6d3d91f88333bb72b38858790604