### PR TITLE
Fix service worker offline fallback

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE = "habit-spark-v1";
+const CACHE = "habit-spark-v2";
 const ASSETS = [
   "./",
   "./index.html",
@@ -39,7 +39,7 @@ self.addEventListener("fetch", (e) => {
       }
       return fresh;
     } catch (err) {
-      return cached || new Response("Offline", {{ status: 200, headers: {{ "Content-Type": "text/plain" }} }});
+      return cached || new Response("Offline", { status: 200, headers: { "Content-Type": "text/plain" } });
     }
   })());
 });


### PR DESCRIPTION
## Summary
- fix the offline fallback response object literal in the service worker
- bump the cache version so clients pick up the new worker

## Testing
- node <<'NODE' ... (simulated offline fetch to verify fallback)


------
https://chatgpt.com/codex/tasks/task_e_68cc6d3f06048333bab0cf2b207c8071